### PR TITLE
Geolocation Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.0.0",
     "date-fns": "^2.30.0",
     "express": "~4.18.1",
+    "geolib": "^3.3.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",

--- a/packages/react-app/src/services/geolocation.ts
+++ b/packages/react-app/src/services/geolocation.ts
@@ -1,8 +1,5 @@
 import { getDistance } from 'geolib';
 
-const RUNTIME_LATITUDE = 38.752962;
-const RUNTIME_LONGITUDE = -9.1478609;
-
 const getLocationPermission = () => {
   if (!navigator.geolocation) {
     return new Promise((resolve, _) => resolve(false));
@@ -27,7 +24,11 @@ const getLocation = () => {
   });
 };
 
-const isAtTheOffice = () => {
+const isWithinRadius = (
+  latitude: number,
+  longitude: number,
+  radius: number
+) => {
   return getLocation().then((position: GeolocationCoordinates | null) => {
     if (!position) {
       return false;
@@ -35,15 +36,15 @@ const isAtTheOffice = () => {
 
     const distance = getDistance(
       { latitude: position.latitude, longitude: position.longitude },
-      { latitude: RUNTIME_LATITUDE, longitude: RUNTIME_LONGITUDE }
+      { latitude: latitude, longitude: longitude }
     );
-    return distance < 500;
+    return distance < radius;
   });
 };
 
 const GeolocationService = {
   getLocationPermission,
   getLocation,
-  isAtTheOffice,
+  isWithinRadius,
 };
 export default GeolocationService;

--- a/packages/react-app/src/services/geolocation.ts
+++ b/packages/react-app/src/services/geolocation.ts
@@ -1,0 +1,49 @@
+import { getDistance } from 'geolib';
+
+const RUNTIME_LATITUDE = 38.752962;
+const RUNTIME_LONGITUDE = -9.1478609;
+
+const getLocationPermission = () => {
+  if (!navigator.geolocation) {
+    return new Promise((resolve, _) => resolve(false));
+  }
+  return navigator.permissions
+    .query({ name: 'geolocation' })
+    .then((result) => result.state !== 'denied');
+};
+
+const getLocation = () => {
+  if (!navigator.geolocation) {
+    return new Promise<GeolocationCoordinates | null>((resolve, _) =>
+      resolve(null)
+    );
+  }
+  return new Promise<GeolocationCoordinates | null>((resolve, _) => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => resolve(pos.coords),
+      (_) => resolve(null),
+      { enableHighAccuracy: true, timeout: 5000, maximumAge: 0 }
+    );
+  });
+};
+
+const isAtTheOffice = () => {
+  return getLocation().then((position: GeolocationCoordinates | null) => {
+    if (!position) {
+      return false;
+    }
+
+    const distance = getDistance(
+      { latitude: position.latitude, longitude: position.longitude },
+      { latitude: RUNTIME_LATITUDE, longitude: RUNTIME_LONGITUDE }
+    );
+    return distance < 500;
+  });
+};
+
+const GeolocationService = {
+  getLocationPermission,
+  getLocation,
+  isAtTheOffice,
+};
+export default GeolocationService;

--- a/packages/react-app/src/services/geolocation.ts
+++ b/packages/react-app/src/services/geolocation.ts
@@ -1,12 +1,11 @@
 import { getDistance } from 'geolib';
 
-const getLocationPermission = () => {
+const getLocationPermission = async () => {
   if (!navigator.geolocation) {
-    return new Promise((resolve, _) => resolve(false));
+    return false;
   }
-  return navigator.permissions
-    .query({ name: 'geolocation' })
-    .then((result) => result.state !== 'denied');
+  const result = await navigator.permissions.query({ name: 'geolocation' });
+  return result.state !== 'denied';
 };
 
 const getLocation = () => {
@@ -24,22 +23,21 @@ const getLocation = () => {
   });
 };
 
-const isWithinRadius = (
+const isWithinRadius = async (
   latitude: number,
   longitude: number,
   radius: number
 ) => {
-  return getLocation().then((position: GeolocationCoordinates | null) => {
-    if (!position) {
-      return false;
-    }
+  const position = await getLocation();
+  if (!position) {
+    return false;
+  }
 
-    const distance = getDistance(
-      { latitude: position.latitude, longitude: position.longitude },
-      { latitude: latitude, longitude: longitude }
-    );
-    return distance < radius;
-  });
+  const distance = getDistance(
+    { latitude: position.latitude, longitude: position.longitude },
+    { latitude: latitude, longitude: longitude }
+  );
+  return distance < radius;
 };
 
 const GeolocationService = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7634,6 +7634,11 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
+geolib@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/geolib/-/geolib-3.3.3.tgz#17f5a0dcdc0b051bd631b66f7131d2c14c54a15b"
+  integrity sha512-YO704pzdB/8QQekQuDmFD5uv5RAwAf4rOUPdcMhdEOz+HoPWD0sC7Qqdwb+LAvwIjXVRawx0QgZlocKYh8PFOQ==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"


### PR DESCRIPTION
This PR adds a geolocation service to be mainly used to determine if the a given user is at the office or not, which can be one of the requirements of the giveaway.

## Changes Description
- Add geolib package which offer functions to perform operations between coordinates
- Add a geolocation service to: request location permission, get the location, verify if the user is at the office