### PR TITLE
[WEB3-45] Winner/rejected modals not showing

### DIFF
--- a/packages/node-app/src/routes/giveaway.route.ts
+++ b/packages/node-app/src/routes/giveaway.route.ts
@@ -29,8 +29,8 @@ router.get('/', listGiveaways);
 router.get('/:id', getGiveaway);
 router.put('/:id/participants', addParticipant);
 router.get('/:id/participants', getParticipants);
+router.put('/:id/participants/:participantId', updateParticipant);
 
 router.post('/', verifyAdmin, upload.single('image'), createGiveaway);
 router.put('/:id', verifyAdmin, upload.single('image'), updateGiveaway);
-router.put('/:id/participants/:participantId', verifyAdmin, updateParticipant);
 router.get('/:id/generate-winners', verifyAdmin, generateWinners);

--- a/packages/react-app/src/components/giveaways/cards/Card.tsx
+++ b/packages/react-app/src/components/giveaways/cards/Card.tsx
@@ -1,9 +1,18 @@
-import { useContext, useState } from 'react';
+import {
+  useContext,
+  useState,
+} from 'react';
 
 import { format } from 'date-fns';
 import { useNavigate } from 'react-router-dom';
 
-import { Box, Card, CardContent, Skeleton, Typography } from '@mui/material';
+import {
+  Box,
+  Card,
+  CardContent,
+  Skeleton,
+  Typography,
+} from '@mui/material';
 
 import Trophy from '../../../assets/Trophy.png';
 import { useParticipants } from '../../../lib/queryClient';
@@ -20,10 +29,15 @@ import PendingApprovalBanner from '../participation/PendingApprovalBanner';
 
 type GiveawayCardProps = {
   giveaway: Giveaway;
+  archived: boolean;
   onWinnersGeneration: () => void;
 };
 
-const GiveawayCard = ({ giveaway, onWinnersGeneration }: GiveawayCardProps) => {
+const GiveawayCard = ({
+  giveaway,
+  archived,
+  onWinnersGeneration,
+}: GiveawayCardProps) => {
   const navigate = useNavigate();
   const userInfo = useContext(UserContext) as UserInfo;
   const { data: participants } = useParticipants(giveaway._id);
@@ -117,26 +131,23 @@ const GiveawayCard = ({ giveaway, onWinnersGeneration }: GiveawayCardProps) => {
           </span>{' '}
           {format(giveaway.endTime, 'MMMM d, yyyy')}
         </Typography>
-        {giveaway.winners.length > 0 && (
+        {archived && (
           <Typography className="winners" gutterBottom>
             <span role="img" aria-label="party emoji">
               🥳
             </span>{' '}
-            {getWinnerStr()}
+            {giveaway.winners.length > 0 ? getWinnerStr() : 'Pending'}
           </Typography>
         )}
-        {giveaway.endTime < new Date() &&
-          participation !== ParticipationState.PENDING_WINNERS && (
-            <Typography className="participants" gutterBottom>
-              <span role="img" aria-label="people">
-                👥
-              </span>{' '}
-              {`${nrConfirmedParticipants} participants`}
-            </Typography>
-          )}
-        {(!participation ||
-          giveaway.endTime > new Date() ||
-          participation === ParticipationState.PENDING_WINNERS) && (
+        {archived && (
+          <Typography className="participants" gutterBottom>
+            <span role="img" aria-label="people">
+              👥
+            </span>{' '}
+            {`${nrConfirmedParticipants} participants`}
+          </Typography>
+        )}
+        {!archived && (
           <ParticipationButton
             giveaway={giveaway}
             onStateChange={onStateChange}

--- a/packages/react-app/src/components/giveaways/participation/ParticipationButton.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ParticipationButton.tsx
@@ -164,22 +164,17 @@ const ParticipationButton = ({
         </MuiAlert>
       </Snackbar>
       {showPendingModal && (
-        <PendingLocationModal
-          open={true}
-          onClose={() => setShowPendingModal(false)}
-        />
+        <PendingLocationModal onClose={() => setShowPendingModal(false)} />
       )}
       {showRejectedModal && (
         <RejectionModal
           giveaway={giveaway}
-          open={true}
           onClose={() => setShowRejectedModal(false)}
         />
       )}
       {showWinnerModal && (
         <WinnerModal
           giveaway={giveaway}
-          open={true}
           onClose={() => setShowWinnerModal(false)}
         />
       )}

--- a/packages/react-app/src/components/giveaways/participation/ParticipationButton.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ParticipationButton.tsx
@@ -9,18 +9,22 @@ import React, {
 import { Snackbar } from '@mui/material';
 import MuiAlert from '@mui/material/Alert';
 
-import { Giveaway, ParticipationState, UserInfo } from '../../../lib/types';
+import {
+  Giveaway,
+  ParticipationState,
+  UserInfo,
+} from '../../../lib/types';
 import { UserContext } from '../../../routes/AuthRoute';
 import FrontendApiClient from '../../../services/backend';
 import ParticipationService from '../../../services/giveawayparticipation';
 import {
   ApprovalPendingButton,
   CheckingButton,
+  GenerateWinnersButton,
   ManageButton,
   NotAllowedButton,
   ParticipateButton,
   ParticipatingButton,
-  GenerateWinnersButton,
 } from './ActionButtons';
 import {
   PendingLocationModal,
@@ -175,7 +179,7 @@ const ParticipationButton = ({
       {showWinnerModal && (
         <WinnerModal
           giveaway={giveaway}
-          open={showWinnerModal}
+          open={true}
           onClose={() => setShowWinnerModal(false)}
         />
       )}

--- a/packages/react-app/src/components/giveaways/participation/StatusModals.tsx
+++ b/packages/react-app/src/components/giveaways/participation/StatusModals.tsx
@@ -1,32 +1,28 @@
 import { useContext } from 'react';
 
-import { Giveaway, UserInfo } from '../../../lib/types';
+import {
+  Giveaway,
+  UserInfo,
+} from '../../../lib/types';
 import { UserContext } from '../../../routes/AuthRoute';
 import Resources from '../../../utils/Resources';
 import OverlayModal from '../../OverlayModal';
 
 type PendingLocationModalProps = {
-  open: boolean;
   darkBackground?: boolean;
   onClose?: () => void;
 };
 
 type GiveawayModalProps = {
-  open: boolean;
-  giveaway?: Giveaway;
+  giveaway: Giveaway;
   darkBackground?: boolean;
   onClose?: () => void;
 };
 
 const PendingLocationModal = ({
-  open,
   onClose,
   darkBackground = true,
 }: PendingLocationModalProps) => {
-  if (!open) {
-    return null;
-  }
-
   return (
     <div>
       <OverlayModal
@@ -47,15 +43,10 @@ const PendingLocationModal = ({
 
 const WinnerModal = ({
   giveaway,
-  open,
   onClose,
   darkBackground = true,
 }: GiveawayModalProps) => {
   const userInfo = useContext(UserContext) as UserInfo;
-
-  if (!open || !giveaway) {
-    return null;
-  }
 
   return (
     <div>
@@ -77,14 +68,9 @@ const WinnerModal = ({
 
 const RejectionModal = ({
   giveaway,
-  open,
   onClose,
   darkBackground = true,
 }: GiveawayModalProps) => {
-  if (!open || !giveaway) {
-    return null;
-  }
-
   return (
     <div>
       <OverlayModal

--- a/packages/react-app/src/pages/manage.tsx
+++ b/packages/react-app/src/pages/manage.tsx
@@ -1,8 +1,23 @@
-import { isAfter, isBefore } from 'date-fns';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import {
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import {
+  isAfter,
+  isBefore,
+} from 'date-fns';
 import Confetti from 'react-confetti';
 
-import { Box, Container, Grid, Snackbar, Typography } from '@mui/material';
+import {
+  Box,
+  Container,
+  Grid,
+  Snackbar,
+  Typography,
+} from '@mui/material';
 import MuiAlert from '@mui/material/Alert';
 import Button from '@mui/material/Button';
 
@@ -15,7 +30,11 @@ import AdminEmptyState from '../components/giveaways/empty/AdminEmptyState';
 import UserEmptyState from '../components/giveaways/empty/UserEmptyState';
 import { splitTimeLeft } from '../hooks/useTimer';
 import { useGiveaways } from '../lib/queryClient';
-import { Giveaway, UserInfo, UserRole } from '../lib/types';
+import {
+  Giveaway,
+  UserInfo,
+  UserRole,
+} from '../lib/types';
 import { UserContext } from '../routes/AuthRoute';
 import ParticipationService from '../services/giveawayparticipation';
 
@@ -206,6 +225,7 @@ const Manage = () => {
                 >
                   <GiveawayCard
                     giveaway={g}
+                    archived={activeTab === Tabs.Archived}
                     onWinnersGeneration={handleWinners}
                   />
                 </Grid>


### PR DESCRIPTION
# Description

This PR fixes an issue with winner and rejected modals not prompting. This was happening because of the addition of admin requirement to update the notified flag of a given participant. The validations of the participant update controller were updated to satisfy the update of the state, and notification flag.

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-45

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

New tests were added to make sure the updated validations are working as expected. Manual tests were performed to verify if the modals are prompting when a user is rejected or wins a giveaway.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
