### PR TITLE
[WEB3-46] Manual input warning

### DIFF
--- a/packages/react-app/src/components/WarningBox.tsx
+++ b/packages/react-app/src/components/WarningBox.tsx
@@ -1,0 +1,20 @@
+import WarningIcon from '@mui/icons-material/Warning';
+import {
+  Box,
+  Typography,
+} from '@mui/material';
+
+type WarningBoxProps = {
+  message: string;
+};
+
+const WarningBox = ({ message }: WarningBoxProps) => {
+  return (
+    <Box className="warning-box">
+      <WarningIcon className="warning-box-icon" />
+      <Typography className="warning-text">{message}</Typography>
+    </Box>
+  );
+};
+
+export default WarningBox;

--- a/packages/react-app/src/pages/edit.tsx
+++ b/packages/react-app/src/pages/edit.tsx
@@ -570,6 +570,7 @@ const EditGiveaway = () => {
                   <Controller
                     name={'manual'}
                     control={control}
+                    defaultValue={true}
                     render={({ field: { ref, ...field } }) => (
                       <Checkbox
                         {...field}

--- a/packages/react-app/src/pages/edit.tsx
+++ b/packages/react-app/src/pages/edit.tsx
@@ -1,9 +1,22 @@
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 
 import { useDropzone } from 'react-dropzone';
-import { Controller, useForm } from 'react-hook-form';
+import {
+  Controller,
+  useForm,
+} from 'react-hook-form';
 import { useMutation } from 'react-query';
-import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import {
+  Navigate,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
 
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined';
@@ -21,10 +34,14 @@ import {
   Typography,
 } from '@mui/material';
 import MuiAlert from '@mui/material/Alert';
-import { DateTimePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import {
+  DateTimePicker,
+  LocalizationProvider,
+} from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 
 import uploadIcon from '../assets/CloudUpload.png';
+import WarningBox from '../components/WarningBox';
 import queryClient, {
   useGiveawayDetails,
   useLocations,
@@ -553,19 +570,23 @@ const EditGiveaway = () => {
                   <Controller
                     name={'manual'}
                     control={control}
-                    defaultValue={data?.manual ? data?.manual : false}
-                    render={({ field: { ref, ...field }, fieldState }) => (
+                    render={({ field: { ref, ...field } }) => (
                       <Checkbox
                         {...field}
-                        checked={field.value}
+                        checked={true}
                         inputRef={ref}
-                        disabled={!!giveawayId}
+                        disabled={true}
                       />
                     )}
                   />
                 }
                 label="Manual giveaway"
                 disabled={!!giveawayId}
+              />
+              <WarningBox
+                message="Automatic raffles will be available in the next
+                        version. The manual option requires an administrator 
+                        to raffle winners when the giveaway ends."
               />
             </Box>
             <Box className="cancel-save-container">

--- a/packages/react-app/src/pages/edit.tsx
+++ b/packages/react-app/src/pages/edit.tsx
@@ -585,9 +585,9 @@ const EditGiveaway = () => {
                 disabled={!!giveawayId}
               />
               <WarningBox
-                message="Automatic raffles will be available in the next
+                message="Automatic giveaways will be available in the next
                         version. The manual option requires an administrator 
-                        to raffle winners when the giveaway ends."
+                        to generate winners when the giveaway ends."
               />
             </Box>
             <Box className="cancel-save-container">

--- a/packages/react-app/src/styles.scss
+++ b/packages/react-app/src/styles.scss
@@ -116,3 +116,17 @@
     margin-left: 10px !important;
   }
 }
+
+.warning-box {
+  background-color: #fff3cd;
+  color: #856404;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  margin-top: 10px;
+
+  &-icon {
+    padding-right: 20px;
+  }
+}


### PR DESCRIPTION
# Description

This PR adds a warning to the manual input when creating a giveaway. Automatic raffles will only be available in the next version.

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-46

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

1. Go to the create new giveaway page
2. Verify the warning near the manual input

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
