### PR TITLE
Add a loading spinner

### DIFF
--- a/packages/react-app/src/components/giveaways/participation/ActionButtons.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ActionButtons.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LoadingButton from '@mui/lab/LoadingButton';
-import { Button, CircularProgress } from '@mui/material';
+import { Button } from '@mui/material';
 
 import { Giveaway, UserInfo } from '../../../lib/types';
 import FrontendApiClient from '../../../services/backend';
@@ -83,19 +83,26 @@ const GenerateWinnersButton = ({
   };
 
   return (
-    <Button
+    <LoadingButton
       className="card-action-btn"
       variant="contained"
       sx={{
         ...ButtonBaseStyle,
         backgroundColor: '#DBDBFB',
         color: '#6D6DF0',
+
+        '&.Mui-disabled': {
+          background: '#6D6DF0',
+          color: 'white',
+        },
       }}
       onClick={generateWinners}
       disableElevation
+      loading={isLoading}
+      disabled={isLoading}
     >
-      {isLoading? <CircularProgress size='1.5rem'/> : 'Generate a winner'}
-    </Button>
+      {!isLoading && 'Generate a winner'}
+    </LoadingButton>
   );
 };
 

--- a/packages/react-app/src/components/giveaways/participation/ActionButtons.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ActionButtons.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import CheckCircleOutlineOutlinedIcon from '@mui/icons-material/CheckCircleOutlineOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LoadingButton from '@mui/lab/LoadingButton';
-import { Button } from '@mui/material';
+import { Button, CircularProgress } from '@mui/material';
 
 import { Giveaway, UserInfo } from '../../../lib/types';
 import FrontendApiClient from '../../../services/backend';
@@ -67,10 +67,16 @@ const GenerateWinnersButton = ({
   successCallback,
   errorCallback,
 }: GenerateWinnersProps) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const generateWinners = () => {
+    setIsLoading(true);
     FrontendApiClient.generateWinners(giveaway._id)
-      .then(() => successCallback())
+      .then(() => {
+        setIsLoading(false);
+        successCallback();
+      })
       .catch((err) => {
+        setIsLoading(false);
         console.log(`problems generating winners: ${err}`);
         errorCallback();
       });
@@ -88,7 +94,7 @@ const GenerateWinnersButton = ({
       onClick={generateWinners}
       disableElevation
     >
-      Generate a winner
+      {isLoading? <CircularProgress size='1.5rem'/> : 'Generate a winner'}
     </Button>
   );
 };

--- a/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
@@ -2,20 +2,20 @@ import { Stack, Typography } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 
 import { Participant } from '../../../lib/types';
+import { useState } from 'react';
 
 type ParticipantEntryProps = {
   participant: Participant;
   actionAllowed: boolean;
   onUpdateState: (participantId: string, newState: string) => void;
-  isLoading: string;
 };
 
 const ParticipantEntry = ({
   participant,
   actionAllowed,
   onUpdateState,
-  isLoading,
 }: ParticipantEntryProps) => {
+  const [isLoading, setIsLoading] = useState<string>('no action');
   return (
     <Stack
       className="participant-entry-container"
@@ -38,8 +38,10 @@ const ParticipantEntry = ({
             },
           }}
           color="error"
-          onClick={() => {
-            onUpdateState(participant.id, 'rejected');
+          onClick={async () => {
+            setIsLoading('rejected');
+            await onUpdateState(participant.id, 'rejected');
+            setIsLoading('no action');
           }}
           disableElevation
           disabled={!actionAllowed || isLoading !== 'no action'}
@@ -60,8 +62,10 @@ const ParticipantEntry = ({
               color: 'white',
             },
           }}
-          onClick={() => {
-            onUpdateState(participant.id, 'confirmed');
+          onClick={async () => {
+            setIsLoading('confirmed');
+            await onUpdateState(participant.id, 'confirmed');
+            setIsLoading('no action');
           }}
           disableElevation
           disabled={!actionAllowed || isLoading !== 'no action'}

--- a/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
@@ -1,4 +1,5 @@
-import { Button, CircularProgress, Stack, Typography } from '@mui/material';
+import { Stack, Typography } from '@mui/material';
+import { LoadingButton } from '@mui/lab';
 
 import { Participant } from '../../../lib/types';
 
@@ -24,30 +25,50 @@ const ParticipantEntry = ({
     >
       <Typography className="participant-name">{participant.name}</Typography>
       <Stack direction={'row'}>
-        <Button
+        <LoadingButton
           className={`action-button reject ${!actionAllowed && 'disabled'}`}
           variant="contained"
+          sx={{
+            backgroundColor: '#DBDBFB',
+            color: '#6D6DF0',
+    
+            '&.Mui-disabled': {
+              background: '#6D6DF0',
+              color: 'white',
+            },
+          }}
           color="error"
           onClick={() => {
             onUpdateState(participant.id, 'rejected');
           }}
           disableElevation
-          disabled={!actionAllowed}
+          disabled={!actionAllowed || isLoading !== 'no action'}
+          loading={isLoading === 'rejected'}
         >
-          {isLoading === 'rejected'? <CircularProgress size='1.5rem'/> : 'Reject'}
-        </Button>
-        <Button
+          {isLoading !=='rejected' && 'Reject'}
+        </LoadingButton>
+        <LoadingButton
           className={`action-button approve ${!actionAllowed && 'disabled'}`}
           variant="contained"
           color="success"
+          sx={{
+            backgroundColor: '#DBDBFB',
+            color: '#6D6DF0',
+    
+            '&.Mui-disabled': {
+              background: '#6D6DF0',
+              color: 'white',
+            },
+          }}
           onClick={() => {
             onUpdateState(participant.id, 'confirmed');
           }}
           disableElevation
-          disabled={!actionAllowed}
+          disabled={!actionAllowed || isLoading !== 'no action'}
+          loading={isLoading === 'confirmed'}
         >
-          {isLoading === 'confirmed'? <CircularProgress size='1.5rem'/> : 'Approve'}
-        </Button>
+          {isLoading !=='confirmed' && 'Approve'}
+        </LoadingButton>
       </Stack>
     </Stack>
   );

--- a/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack, Typography } from '@mui/material';
+import { Button, CircularProgress, Stack, Typography } from '@mui/material';
 
 import { Participant } from '../../../lib/types';
 
@@ -6,12 +6,14 @@ type ParticipantEntryProps = {
   participant: Participant;
   actionAllowed: boolean;
   onUpdateState: (participantId: string, newState: string) => void;
+  isLoading: string;
 };
 
 const ParticipantEntry = ({
   participant,
   actionAllowed,
   onUpdateState,
+  isLoading,
 }: ParticipantEntryProps) => {
   return (
     <Stack
@@ -32,7 +34,7 @@ const ParticipantEntry = ({
           disableElevation
           disabled={!actionAllowed}
         >
-          Reject
+          {isLoading === 'rejected'? <CircularProgress size='1.5rem'/> : 'Reject'}
         </Button>
         <Button
           className={`action-button approve ${!actionAllowed && 'disabled'}`}
@@ -44,7 +46,7 @@ const ParticipantEntry = ({
           disableElevation
           disabled={!actionAllowed}
         >
-          Approve
+          {isLoading === 'confirmed'? <CircularProgress size='1.5rem'/> : 'Approve'}
         </Button>
       </Stack>
     </Stack>

--- a/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
+++ b/packages/react-app/src/components/giveaways/participation/ParticipantEntry.tsx
@@ -15,7 +15,14 @@ const ParticipantEntry = ({
   actionAllowed,
   onUpdateState,
 }: ParticipantEntryProps) => {
-  const [isLoading, setIsLoading] = useState<string>('no action');
+  const [loadingStatus, setLoadingStatus] = useState<string>('no action');
+
+  const onButtonClick = async(newLoadingStatus: string) => {
+    setLoadingStatus(newLoadingStatus);
+    await onUpdateState(participant.id, newLoadingStatus);
+    setLoadingStatus('no action');
+  }
+
   return (
     <Stack
       className="participant-entry-container"
@@ -28,50 +35,28 @@ const ParticipantEntry = ({
         <LoadingButton
           className={`action-button reject ${!actionAllowed && 'disabled'}`}
           variant="contained"
-          sx={{
-            backgroundColor: '#DBDBFB',
-            color: '#6D6DF0',
-    
-            '&.Mui-disabled': {
-              background: '#6D6DF0',
-              color: 'white',
-            },
-          }}
           color="error"
-          onClick={async () => {
-            setIsLoading('rejected');
-            await onUpdateState(participant.id, 'rejected');
-            setIsLoading('no action');
+          onClick={() => {
+            onButtonClick('rejected')
           }}
           disableElevation
-          disabled={!actionAllowed || isLoading !== 'no action'}
-          loading={isLoading === 'rejected'}
+          disabled={!actionAllowed || loadingStatus !== 'no action'}
+          loading={loadingStatus === 'rejected'}
         >
-          {isLoading !=='rejected' && 'Reject'}
+          {loadingStatus !=='rejected' && 'Reject'}
         </LoadingButton>
         <LoadingButton
           className={`action-button approve ${!actionAllowed && 'disabled'}`}
           variant="contained"
           color="success"
-          sx={{
-            backgroundColor: '#DBDBFB',
-            color: '#6D6DF0',
-    
-            '&.Mui-disabled': {
-              background: '#6D6DF0',
-              color: 'white',
-            },
-          }}
-          onClick={async () => {
-            setIsLoading('confirmed');
-            await onUpdateState(participant.id, 'confirmed');
-            setIsLoading('no action');
+          onClick={() => {
+            onButtonClick('confirmed')
           }}
           disableElevation
-          disabled={!actionAllowed || isLoading !== 'no action'}
-          loading={isLoading === 'confirmed'}
+          disabled={!actionAllowed || loadingStatus !== 'no action'}
+          loading={loadingStatus === 'confirmed'}
         >
-          {isLoading !=='confirmed' && 'Approve'}
+          {loadingStatus !=='confirmed' && 'Approve'}
         </LoadingButton>
       </Stack>
     </Stack>

--- a/packages/react-app/src/pages/edit.tsx
+++ b/packages/react-app/src/pages/edit.tsx
@@ -24,6 +24,7 @@ import {
   Box,
   Button,
   Checkbox,
+  CircularProgress,
   Container,
   FormControlLabel,
   Grid,
@@ -90,6 +91,7 @@ const EditGiveaway = () => {
   const [binImageFile, setBinImageFile] = useState<File>();
   const [imageURL, setImageURL] = useState<string>('');
   const [imageError, setImageError] = useState<string | undefined>(undefined);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const onDrop = useCallback((files: File[]) => {
     setImageURL(URL.createObjectURL(files[0]));
@@ -125,6 +127,7 @@ const EditGiveaway = () => {
   const saveMutation = useMutation({
     mutationFn: (data: FormData) => API.saveGiveaway(data),
     onError: (e: any) => {
+      setIsLoading(false);
       if (Array.isArray(e.data.error)) {
         addServerErrors(e.data.error, setError);
       } else if (e.data.error) {
@@ -132,6 +135,7 @@ const EditGiveaway = () => {
       }
     },
     onSuccess: () => {
+      setIsLoading(false);
       navigate(-1);
       queryClient.invalidateQueries('giveaways');
       if (giveawayId) {
@@ -171,6 +175,7 @@ const EditGiveaway = () => {
         }
       });
     }
+    setIsLoading(true);
     saveMutation.mutate(formData);
   };
 
@@ -605,7 +610,7 @@ const EditGiveaway = () => {
                 onClick={handleSubmit(saveGiveaway)}
                 disableElevation
               >
-                Save
+                {isLoading ? <CircularProgress size='1.5rem'/> : 'Save'}
               </Button>
             </Box>
           </Grid>

--- a/packages/react-app/src/pages/edit.tsx
+++ b/packages/react-app/src/pages/edit.tsx
@@ -245,6 +245,7 @@ const EditGiveaway = () => {
             onClick={() => {
               navigate(-1);
             }}
+            disabled={isLoading}
           >
             Back
           </Button>
@@ -601,6 +602,7 @@ const EditGiveaway = () => {
                 variant="outlined"
                 onClick={() => navigate(-1)}
                 disableElevation
+                disabled={isLoading}
               >
                 Cancel
               </Button>

--- a/packages/react-app/src/pages/edit.tsx
+++ b/packages/react-app/src/pages/edit.tsx
@@ -24,7 +24,6 @@ import {
   Box,
   Button,
   Checkbox,
-  CircularProgress,
   Container,
   FormControlLabel,
   Grid,
@@ -40,6 +39,7 @@ import {
   LocalizationProvider,
 } from '@mui/x-date-pickers';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { LoadingButton } from '@mui/lab';
 
 import uploadIcon from '../assets/CloudUpload.png';
 import WarningBox from '../components/WarningBox';
@@ -604,14 +604,25 @@ const EditGiveaway = () => {
               >
                 Cancel
               </Button>
-              <Button
+              <LoadingButton
                 className="save-btn"
                 variant="contained"
+                sx={{
+                  backgroundColor: '#DBDBFB',
+                  color: '#6D6DF0',
+          
+                  '&.Mui-disabled': {
+                    background: '#6D6DF0',
+                    color: 'white',
+                  },
+                }}
                 onClick={handleSubmit(saveGiveaway)}
                 disableElevation
+                loading={isLoading}
+                disabled={isLoading}
               >
-                {isLoading ? <CircularProgress size='1.5rem'/> : 'Save'}
-              </Button>
+                {!isLoading && 'Save'}
+              </LoadingButton>
             </Box>
           </Grid>
         </Grid>

--- a/packages/react-app/src/pages/participants.tsx
+++ b/packages/react-app/src/pages/participants.tsx
@@ -28,6 +28,7 @@ const ParticipantsManagerPage = () => {
   const [giveaway, setGiveaway] = useState<Giveaway>();
   const [participants, setParticipants] = useState(participantsData);
   const [error, setError] = useState(false);
+  const [isLoading, setIsLoading] = useState<string>('no action');
 
   const ended = useMemo(() => {
     if (!giveaway) return true;
@@ -49,6 +50,8 @@ const ParticipantsManagerPage = () => {
   const updateParticipant = async (participantId: string, newState: string) => {
     if (!giveawayId) return;
 
+    setIsLoading(newState);
+
     await FrontendApiClient.manageParticipant(
       giveawayId,
       participantId,
@@ -64,6 +67,7 @@ const ParticipantsManagerPage = () => {
     queryClient.invalidateQueries(['giveaways']);
     queryClient.invalidateQueries(['details', giveawayId]);
     queryClient.invalidateQueries(['participants', giveawayId]);
+    setIsLoading('no action');
   };
 
   const closeError = () => {
@@ -94,6 +98,7 @@ const ParticipantsManagerPage = () => {
               participant={participant}
               actionAllowed={!ended}
               onUpdateState={updateParticipant}
+              isLoading={isLoading}
             />
           ))}
         </Stack>

--- a/packages/react-app/src/pages/participants.tsx
+++ b/packages/react-app/src/pages/participants.tsx
@@ -28,7 +28,6 @@ const ParticipantsManagerPage = () => {
   const [giveaway, setGiveaway] = useState<Giveaway>();
   const [participants, setParticipants] = useState(participantsData);
   const [error, setError] = useState(false);
-  const [isLoading, setIsLoading] = useState<string>('no action');
 
   const ended = useMemo(() => {
     if (!giveaway) return true;
@@ -47,27 +46,23 @@ const ParticipantsManagerPage = () => {
     return participants.filter((p) => p.state === 'pending');
   }, [participants]);
 
-  const updateParticipant = async (participantId: string, newState: string) => {
+  const updateParticipant = (participantId: string, newState: string) => {
     if (!giveawayId) return;
 
-    setIsLoading(newState);
-
-    await FrontendApiClient.manageParticipant(
+    return FrontendApiClient.manageParticipant(
       giveawayId,
       participantId,
       newState,
       () => {
         setParticipants(participants.filter((p) => p.id !== participantId));
+        queryClient.invalidateQueries(['giveaways']);
+        queryClient.invalidateQueries(['details', giveawayId]);
+        queryClient.invalidateQueries(['participants', giveawayId]);
       },
       () => {
         setError(true);
       }
     );
-
-    queryClient.invalidateQueries(['giveaways']);
-    queryClient.invalidateQueries(['details', giveawayId]);
-    queryClient.invalidateQueries(['participants', giveawayId]);
-    setIsLoading('no action');
   };
 
   const closeError = () => {
@@ -98,7 +93,6 @@ const ParticipantsManagerPage = () => {
               participant={participant}
               actionAllowed={!ended}
               onUpdateState={updateParticipant}
-              isLoading={isLoading}
             />
           ))}
         </Stack>


### PR DESCRIPTION
# Description

Add a loading spinner while waiting for response to:
- button 'save'  when creating or editing a giveaway;
- button 'generate a winner' when it is pressed
- buttons 'approve' and 'reject' when approving/rejecting a pending participant

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-56

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

while using the app, as an administrator:
- created a location; 
- created a giveaway, that has the location as a condition;
- edited the description of that giveaway;
then, as a user:
- turn localization on my device off;
- participate on the giveaway;
then, again as admin:
- approve the pending participant;
- after the giveaway timer ends generate a winner;


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
