### PR TITLE
Archive invalid giveaways

### DIFF
--- a/packages/node-app/src/controllers/giveaway.controller.ts
+++ b/packages/node-app/src/controllers/giveaway.controller.ts
@@ -11,7 +11,7 @@ import {
   fileToBase64,
   getDefinedFields,
   giveawayStats,
-  giveawayStatus,
+  isGiveawayInvalid,
   giveawayWinners,
   handleError,
 } from '../utils/model.utils';
@@ -25,7 +25,7 @@ export const listGiveaways = async (req: Request, res: Response) => {
   try {
     let giveaways = await Giveaway.find()
       .select(
-        'title description startTime endTime winners requirements prize image participants manual'
+        'title description startTime endTime winners requirements prize image participants manual numberOfWinners'
       )
       .lean();
 
@@ -33,7 +33,7 @@ export const listGiveaways = async (req: Request, res: Response) => {
       ...omit(giveaway, ['participants']),
       winners: giveawayWinners(giveaway),
       stats: giveawayStats(giveaway),
-      status: giveawayStatus(giveaway),
+      isInvalid: isGiveawayInvalid(giveaway),
     }));
 
     res.status(200).json(giveaways);

--- a/packages/node-app/src/controllers/giveaway.controller.ts
+++ b/packages/node-app/src/controllers/giveaway.controller.ts
@@ -1,25 +1,17 @@
-import {
-  Request,
-  Response,
-} from 'express';
+import { Request, Response } from 'express';
 import fs from 'fs';
 import { omit } from 'lodash';
 
 import { giveawaysContract } from '../contracts';
-import {
-  Giveaway,
-  ParticipantState,
-} from '../models/giveaway.model';
+import { Giveaway, ParticipantState } from '../models/giveaway.model';
 import { Location } from '../models/location.model';
 import { UserRole } from '../models/user.model';
-import {
-  hasEnded,
-  isoStringToSecondsTimestamp,
-} from '../utils/date.utils';
+import { hasEnded, isoStringToSecondsTimestamp } from '../utils/date.utils';
 import {
   fileToBase64,
   getDefinedFields,
   giveawayStats,
+  giveawayStatus,
   giveawayWinners,
   handleError,
 } from '../utils/model.utils';
@@ -27,11 +19,7 @@ import {
   getParticipant,
   validateParticipant,
 } from '../utils/validations.utils';
-import {
-  decrypt,
-  encrypt,
-  objectIdToBytes24,
-} from '../utils/web3.utils';
+import { decrypt, encrypt, objectIdToBytes24 } from '../utils/web3.utils';
 
 export const listGiveaways = async (req: Request, res: Response) => {
   try {
@@ -45,6 +33,7 @@ export const listGiveaways = async (req: Request, res: Response) => {
       ...omit(giveaway, ['participants']),
       winners: giveawayWinners(giveaway),
       stats: giveawayStats(giveaway),
+      status: giveawayStatus(giveaway),
     }));
 
     res.status(200).json(giveaways);

--- a/packages/node-app/src/controllers/giveaway.controller.ts
+++ b/packages/node-app/src/controllers/giveaway.controller.ts
@@ -5,10 +5,7 @@ import { omit } from 'lodash';
 import { isAfter, isBefore } from 'date-fns';
 
 import { giveawaysContract } from '../contracts';
-import {
-  Giveaway,
-  ParticipantState,
-} from '../models/giveaway.model';
+import { Giveaway, ParticipantState } from '../models/giveaway.model';
 import { GiveawayLog } from '../models/log_data.model';
 import { Location } from '../models/location.model';
 import { UserRole } from '../models/user.model';
@@ -32,7 +29,7 @@ import {
 import { decrypt, encrypt, objectIdToBytes24 } from '../utils/web3.utils';
 import { parse } from 'querystring';
 
-import { agenda, scheduleWinnerGeneration} from '../utils/agenda.utils';
+import { agenda, scheduleWinnerGeneration } from '../utils/agenda.utils';
 
 export const listGiveaways = async (req: Request, res: Response) => {
   try {
@@ -43,16 +40,16 @@ export const listGiveaways = async (req: Request, res: Response) => {
       .lean();
 
     if (req.query.active) {
-      const active = req.query.active === 'true'
+      const active = req.query.active === 'true';
       const activeGiveaways = getActiveGiveaways(giveaways, req.user.role);
-      
+
       if (active) {
-         giveaways = activeGiveaways
+        giveaways = activeGiveaways;
       } else {
-         giveaways = giveaways.filter((g) => !activeGiveaways.includes(g))
+        giveaways = giveaways.filter((g) => !activeGiveaways.includes(g));
       }
-   }
-   giveaways = giveaways.map((giveaway) => ({
+    }
+    giveaways = giveaways.map((giveaway) => ({
       ...omit(giveaway, ['participants', 'numberOfWinners']),
       winners: giveawayWinners(giveaway),
       stats: giveawayStats(giveaway),
@@ -71,7 +68,12 @@ export const getGiveaway = async (req: Request, res: Response) => {
     let giveaway = await Giveaway.findById(req.params.id).lean();
     const { participants } = giveaway;
     const stats = giveawayStats(giveaway);
-    const winningChance = giveawayWinningChance(req.user.email, stats, participants, giveaway);
+    const winningChance = giveawayWinningChance(
+      req.user.email,
+      stats,
+      participants,
+      giveaway
+    );
     giveaway = {
       ...omit(giveaway, ['participants']),
       winners: giveawayWinners(giveaway),
@@ -177,10 +179,12 @@ export const updateGiveaway = async (req: Request, res: Response) => {
       prize,
       rules,
       image,
-      manual
+      manual,
     });
     const oldGiveaway = await Giveaway.findById(id);
-    const giveaway = await Giveaway.findByIdAndUpdate(id, updateFields, { new: true });
+    const giveaway = await Giveaway.findByIdAndUpdate(id, updateFields, {
+      new: true,
+    });
     await GiveawayLog.create({
       action: 'update-giveaway',
       author: req.user.email,

--- a/packages/node-app/src/controllers/giveaway.controller.ts
+++ b/packages/node-app/src/controllers/giveaway.controller.ts
@@ -30,7 +30,7 @@ export const listGiveaways = async (req: Request, res: Response) => {
       .lean();
 
     giveaways = giveaways.map((giveaway) => ({
-      ...omit(giveaway, ['participants']),
+      ...omit(giveaway, ['participants', 'numberOfWinners']),
       winners: giveawayWinners(giveaway),
       stats: giveawayStats(giveaway),
       isInvalid: isGiveawayInvalid(giveaway),

--- a/packages/node-app/src/swagger.json
+++ b/packages/node-app/src/swagger.json
@@ -1,714 +1,716 @@
 {
-    "openapi": "3.0.0",
-    "info": {
-        "title": "Web 3.0 Roulette",
-        "description": "Web 3.0 app to manage giveaways",
-        "contact": {
-            "name": "GitHub",
-            "url": "https://github.com/runtimerevolution/web3-roulette"
-        },
-        "version": "1.0.0"
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Web 3.0 Roulette",
+    "description": "Web 3.0 app to manage giveaways",
+    "contact": {
+      "name": "GitHub",
+      "url": "https://github.com/runtimerevolution/web3-roulette"
     },
-    "servers": [
-        {
-            "url": "https://luckydart-api.fly.dev",
-            "description": "Public API"
-        },
-        {
-            "url": "http://localhost:3000",
-            "description": "Local API"
-        }
-    ],
-    "paths": {
-        "/giveaways": {
-            "get": {
-                "tags": ["giveaways"],
-                "description": "Get all giveaways",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GiveawayListItem"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "post": {
-                "tags": ["giveaways", "admin"],
-                "description": "Create new giveaway",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "title": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "description": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "startTime": {
-                                        "type": "string",
-                                        "format": "date-time",
-                                        "required": true
-                                    },
-                                    "endTime": {
-                                        "type": "string",
-                                        "format": "date-time",
-                                        "required": true
-                                    },
-                                    "numberOfWinners": {
-                                        "type": "number",
-                                        "required": true
-                                    },
-                                    "requirements": {
-                                        "$ref": "#/components/schemas/Requirements"
-                                    },
-                                    "prize": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "image": {
-                                        "type": "string",
-                                        "format": "binary",
-                                        "required": true
-                                    },
-                                    "rules": {
-                                        "type": "string"
-                                    },
-                                    "manual": {
-                                        "type": "boolean"
-                                    }
-                                },
-                                "encoding": {
-                                    "image": {
-                                        "contentType": ["image/png", "image/jpeg"]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GiveawayItem"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/giveaways/{giveawayId}": {
-            "get": {
-                "tags": ["giveaways"],
-                "description": "Get giveaway",
-                "parameters": [
-                    {
-                      "name": "giveawayId",
-                      "in": "query",
-                      "description": "ID of the giveaway",
-                      "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GiveawayItem"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "put": {
-                "tags": ["giveaways", "admin"],
-                "description": "Update giveaway",
-                "parameters": [
-                    {
-                      "name": "giveawayId",
-                      "in": "query",
-                      "description": "ID of the giveaway",
-                      "required": true
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "title": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "description": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "prize": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "image": {
-                                        "type": "string",
-                                        "format": "binary",
-                                        "required": true
-                                    },
-                                    "rules": {
-                                        "type": "string"
-                                    },
-                                    "manual": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Updated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GiveawayItem"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/giveaway/{giveawayId}/generate-winners": {
-            "get": {
-                "tags": ["giveaways", "admin"],
-                "description": "Generate giveaway winners",
-                "parameters": [
-                    {
-                      "name": "giveawayId",
-                      "in": "query",
-                      "description": "ID of the giveaway",
-                      "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Generated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {
-                                                "type": "string"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/giveaways/{giveawayId}/participants": {
-            "get": {
-                "tags": ["giveaways"],
-                "description": "Get giveaway participants",
-                "parameters": [
-                    {
-                      "name": "giveawayId",
-                      "in": "query",
-                      "description": "ID of the giveaway",
-                      "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "id": {
-                                                "type": "string"
-                                            },
-                                            "name": {
-                                                "type": "string"
-                                            },
-                                            "state": {
-                                                "type": "string",
-                                                "enum": ["pending", "confirmed", "rejected"]
-                                            },
-                                            "notified": {
-                                                "type": "boolean"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/giveaways/{giveawayId}/participants/{participantId}": {
-            "put": {
-                "tags": ["giveaways"],
-                "description": "Update participant state",
-                "parameters": [
-                    {
-                      "name": "giveawayId",
-                      "in": "query",
-                      "description": "ID of the giveaway",
-                      "required": true
-                    },
-                    {
-                        "name": "participantId",
-                        "in": "query",
-                        "description": "ID of the participant",
-                        "required": true
-                    },
-                    {
-                        "name": "state",
-                        "in": "body",
-                        "description": "New state of the participant",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "example": {
-                                        "message": "Participant updated successfully"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/locations": {
-            "get": {
-                "tags": ["locations"],
-                "description": "Get all locations",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/LocationItem"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "post": {
-                "tags": ["locations", "admin"],
-                "description": "Create new location",
-                "parameters": [
-                    {
-                        "name": "name",
-                        "in": "body",
-                        "required": true
-                    },
-                    {
-                        "name": "latitude",
-                        "in": "body",
-                        "required": true
-                    },
-                    {
-                        "name": "longitude",
-                        "in": "body",
-                        "required": true
-                    },
-                    {
-                        "name": "radius",
-                        "in": "body",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LocationItem"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/locations/{locationId}": {
-            "put": {
-                "tags": ["locations", "admin"],
-                "description": "Update location",
-                "parameters": [
-                    {
-                      "name": "locationId",
-                      "in": "query",
-                      "description": "ID of the locatiton",
-                      "required": true
-                    },
-                    {
-                        "name": "name",
-                        "in": "body",
-                        "required": true
-                    },
-                    {
-                        "name": "latitude",
-                        "in": "body",
-                        "required": true
-                    },
-                    {
-                        "name": "longitude",
-                        "in": "body",
-                        "required": true
-                    },
-                    {
-                        "name": "radius",
-                        "in": "body",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Updated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/LocationItem"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["locations", "admin"],
-                "description": "Delete location",
-                "parameters": [
-                    {
-                      "name": "locationId",
-                      "in": "query",
-                      "description": "ID of the locatiton",
-                      "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Deleted"
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        },
-        "/login": {
-            "post": {
-                "tags": ["authentication"],
-                "description": "Login user",
-                "parameters": [
-                    {
-                      "name": "tokenType",
-                      "in": "query",
-                      "required": true
-                    },
-                    {
-                        "name": "accessToken",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "API access token",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "example": {
-                                        "token": "auth-token"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-
-            }
-        },
-        "/me": {
-            "get": {
-                "tags": ["authentication"],
-                "description": "Get user",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "email": { "type": "string" },
-                                        "name": { "type": "string" },
-                                        "role": {
-                                            "type": "string",
-                                            "enum": ["user", "admin"]
-                                        },
-                                        "units": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string",
-                                                "enum": ["node", "rails", "python"]
-                                            }
-                                        },
-                                        "picture": { "type": "string" }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-            }
-        }
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "https://luckydart-api.fly.dev",
+      "description": "Public API"
     },
-    "components": {
-        "schemas": {
-            "GiveawayListItem": {
+    {
+      "url": "http://localhost:3000",
+      "description": "Local API"
+    }
+  ],
+  "paths": {
+    "/giveaways": {
+      "get": {
+        "tags": ["giveaways"],
+        "description": "Get all giveaways",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GiveawayListItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      },
+      "post": {
+        "tags": ["giveaways", "admin"],
+        "description": "Create new giveaway",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
                 "type": "object",
                 "properties": {
-                    "_id": { "type": "string" },
-                    "title": { "type": "string" },
-                    "description": { "type": "string" },
-                    "startTime": { "type": "string", "format": "date-time" },
-                    "endTime": { "type": "string", "format": "date-time" },
-                    "requirements": { "$ref": "#/components/schemas/Requirements" },
-                    "prize": { "type": "string" },
-                    "image": { "type": "string" },
-                    "manual": { "type": "boolean" },
-                    "winners": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": { "type": "string" },
-                                "name": { "type": "string" }
-                            }
-                        }
-                    },
-                    "stats": {
-                        "type": "object",
-                        "properties": {
-                            "nrConfirmedParticipants": { "type": "number" },
-                            "nrPendingParticipants": { "type": "number" }
-                        }
+                  "title": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "description": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "startTime": {
+                    "type": "string",
+                    "format": "date-time",
+                    "required": true
+                  },
+                  "endTime": {
+                    "type": "string",
+                    "format": "date-time",
+                    "required": true
+                  },
+                  "numberOfWinners": {
+                    "type": "number",
+                    "required": true
+                  },
+                  "requirements": {
+                    "$ref": "#/components/schemas/Requirements"
+                  },
+                  "prize": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "image": {
+                    "type": "string",
+                    "format": "binary",
+                    "required": true
+                  },
+                  "rules": {
+                    "type": "string"
+                  },
+                  "manual": {
+                    "type": "boolean"
+                  }
+                },
+                "encoding": {
+                  "image": {
+                    "contentType": ["image/png", "image/jpeg"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GiveawayItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/giveaways/{giveawayId}": {
+      "get": {
+        "tags": ["giveaways"],
+        "description": "Get giveaway",
+        "parameters": [
+          {
+            "name": "giveawayId",
+            "in": "query",
+            "description": "ID of the giveaway",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GiveawayItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      },
+      "put": {
+        "tags": ["giveaways", "admin"],
+        "description": "Update giveaway",
+        "parameters": [
+          {
+            "name": "giveawayId",
+            "in": "query",
+            "description": "ID of the giveaway",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "description": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "prize": {
+                    "type": "string",
+                    "required": true
+                  },
+                  "image": {
+                    "type": "string",
+                    "format": "binary",
+                    "required": true
+                  },
+                  "rules": {
+                    "type": "string"
+                  },
+                  "manual": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GiveawayItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/giveaway/{giveawayId}/generate-winners": {
+      "get": {
+        "tags": ["giveaways", "admin"],
+        "description": "Generate giveaway winners",
+        "parameters": [
+          {
+            "name": "giveawayId",
+            "in": "query",
+            "description": "ID of the giveaway",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
                     }
+                  }
                 }
-            },
-            "GiveawayItem": {
-                "type": "object",
-                "properties": {
-                    "_id": { "type": "string" },
-                    "title": { "type": "string" },
-                    "description": { "type": "string" },
-                    "startTime": { "type": "string", "format": "date-time" },
-                    "endTime": { "type": "string", "format": "date-time" },
-                    "participants": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": { "type": "string" },
-                                "name": { "type": "string" },
-                                "state": {
-                                    "type": "string",
-                                    "enum": ["pending", "confirmed", "rejected"]
-                                },
-                                "notified": { "type": "boolean" }
-                            }
-                        }
-                    },
-                    "winners": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": { "type": "string" }
-                            }
-                        }
-                    },
-                    "numberOfWinners": { "type": "number" },
-                    "requirements": { "$ref": "#/components/schemas/Requirements" },
-                    "prize": { "type": "string" },
-                    "image": { "type": "string" },
-                    "manual": { "type": "boolean" }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/giveaways/{giveawayId}/participants": {
+      "get": {
+        "tags": ["giveaways"],
+        "description": "Get giveaway participants",
+        "parameters": [
+          {
+            "name": "giveawayId",
+            "in": "query",
+            "description": "ID of the giveaway",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "state": {
+                        "type": "string",
+                        "enum": ["pending", "confirmed", "rejected"]
+                      },
+                      "notified": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
                 }
-            },
-            "Requirements": {
-                "type": "object",
-                "properties": {
-                    "unit": {
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/giveaways/{giveawayId}/participants/{participantId}": {
+      "put": {
+        "tags": ["giveaways"],
+        "description": "Update participant state",
+        "parameters": [
+          {
+            "name": "giveawayId",
+            "in": "query",
+            "description": "ID of the giveaway",
+            "required": true
+          },
+          {
+            "name": "participantId",
+            "in": "query",
+            "description": "ID of the participant",
+            "required": true
+          },
+          {
+            "name": "state",
+            "in": "body",
+            "description": "New state of the participant",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "message": "Participant updated successfully"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/locations": {
+      "get": {
+        "tags": ["locations"],
+        "description": "Get all locations",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LocationItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      },
+      "post": {
+        "tags": ["locations", "admin"],
+        "description": "Create new location",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "body",
+            "required": true
+          },
+          {
+            "name": "latitude",
+            "in": "body",
+            "required": true
+          },
+          {
+            "name": "longitude",
+            "in": "body",
+            "required": true
+          },
+          {
+            "name": "radius",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocationItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/locations/{locationId}": {
+      "put": {
+        "tags": ["locations", "admin"],
+        "description": "Update location",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "query",
+            "description": "ID of the locatiton",
+            "required": true
+          },
+          {
+            "name": "name",
+            "in": "body",
+            "required": true
+          },
+          {
+            "name": "latitude",
+            "in": "body",
+            "required": true
+          },
+          {
+            "name": "longitude",
+            "in": "body",
+            "required": true
+          },
+          {
+            "name": "radius",
+            "in": "body",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocationItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["locations", "admin"],
+        "description": "Delete location",
+        "parameters": [
+          {
+            "name": "locationId",
+            "in": "query",
+            "description": "ID of the locatiton",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "tags": ["authentication"],
+        "description": "Login user",
+        "parameters": [
+          {
+            "name": "tokenType",
+            "in": "query",
+            "required": true
+          },
+          {
+            "name": "accessToken",
+            "in": "query",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "API access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "example": {
+                    "token": "auth-token"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid Authentication"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "tags": ["authentication"],
+        "description": "Get user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "email": { "type": "string" },
+                    "name": { "type": "string" },
+                    "role": {
+                      "type": "string",
+                      "enum": ["user", "admin"]
+                    },
+                    "units": {
+                      "type": "array",
+                      "items": {
                         "type": "string",
                         "enum": ["node", "rails", "python"]
+                      }
                     },
-                    "location": { "type": "string" }
+                    "picture": { "type": "string" }
+                  }
                 }
-            },
-            "LocationItem": {
-                "type": "object",
-                "properties": {
-                    "name": { "type": "string", "required": true },
-                    "latitude": { "type": "number", "required": true },
-                    "longitude": { "type": "number", "required": true },
-                    "radius": { "type": "number", "required": true }
-                }
+              }
             }
+          },
+          "4XX": {
+            "description": "Invalid or missing information"
+          },
+          "5XX": {
+            "description": "Unexpected error"
+          }
         }
+      }
     }
+  },
+  "components": {
+    "schemas": {
+      "GiveawayListItem": {
+        "type": "object",
+        "properties": {
+          "_id": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "startTime": { "type": "string", "format": "date-time" },
+          "endTime": { "type": "string", "format": "date-time" },
+          "requirements": { "$ref": "#/components/schemas/Requirements" },
+          "prize": { "type": "string" },
+          "image": { "type": "string" },
+          "manual": { "type": "boolean" },
+          "winners": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" }
+              }
+            }
+          },
+          "stats": {
+            "type": "object",
+            "properties": {
+              "nrConfirmedParticipants": { "type": "number" },
+              "nrPendingParticipants": { "type": "number" }
+            }
+          },
+          "isInvalid": {
+            "type": "boolean"
+          }
+        }
+      },
+      "GiveawayItem": {
+        "type": "object",
+        "properties": {
+          "_id": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "startTime": { "type": "string", "format": "date-time" },
+          "endTime": { "type": "string", "format": "date-time" },
+          "participants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "state": {
+                  "type": "string",
+                  "enum": ["pending", "confirmed", "rejected"]
+                },
+                "notified": { "type": "boolean" }
+              }
+            }
+          },
+          "winners": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" }
+              }
+            }
+          },
+          "numberOfWinners": { "type": "number" },
+          "requirements": { "$ref": "#/components/schemas/Requirements" },
+          "prize": { "type": "string" },
+          "image": { "type": "string" },
+          "manual": { "type": "boolean" }
+        }
+      },
+      "Requirements": {
+        "type": "object",
+        "properties": {
+          "unit": {
+            "type": "string",
+            "enum": ["node", "rails", "python"]
+          },
+          "location": { "type": "string" }
+        }
+      },
+      "LocationItem": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "required": true },
+          "latitude": { "type": "number", "required": true },
+          "longitude": { "type": "number", "required": true },
+          "radius": { "type": "number", "required": true }
+        }
+      }
+    }
+  }
 }

--- a/packages/node-app/src/swagger.json
+++ b/packages/node-app/src/swagger.json
@@ -9,137 +9,42 @@
     },
     "version": "1.0.0"
   },
-    "servers": [
-        {
-            "url": "https://luckydart-api.fly.dev",
-            "description": "Public API"
-        },
-        {
-            "url": "http://localhost:3000",
-            "description": "Local API"
-        }
-    ],
-    "paths": {
-        "/giveaways": {
-            "get": {
-                "tags": ["giveaways"],
-                "description": "Get all giveaways",
-                "parameters": [
-                    {
-                        "name": "active",
-                        "in":"query",
-                        "required": false,
-                        "schema": {
-                            "type": "boolean"
-                        },
-                        "description": "Flag used to filter out active or archived giveaways.By default returns all of them"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GiveawayListItem"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
-                }
-                
+  "servers": [
+    {
+      "url": "https://luckydart-api.fly.dev",
+      "description": "Public API"
+    },
+    {
+      "url": "http://localhost:3000",
+      "description": "Local API"
+    }
+  ],
+  "paths": {
+    "/giveaways": {
+      "get": {
+        "tags": ["giveaways"],
+        "description": "Get all giveaways",
+        "parameters": [
+          {
+            "name": "active",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
             },
-            "post": {
-                "tags": ["giveaways", "admin"],
-                "description": "Create new giveaway",
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "title": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "description": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "startTime": {
-                                        "type": "string",
-                                        "format": "date-time",
-                                        "required": true
-                                    },
-                                    "endTime": {
-                                        "type": "string",
-                                        "format": "date-time",
-                                        "required": true
-                                    },
-                                    "numberOfWinners": {
-                                        "type": "number",
-                                        "required": true
-                                    },
-                                    "requirements": {
-                                        "$ref": "#/components/schemas/Requirements"
-                                    },
-                                    "prize": {
-                                        "type": "string",
-                                        "required": true
-                                    },
-                                    "image": {
-                                        "type": "string",
-                                        "format": "binary",
-                                        "required": true
-                                    },
-                                    "rules": {
-                                        "type": "string"
-                                    },
-                                    "manual": {
-                                        "type": "boolean"
-                                    }
-                                },
-                                "encoding": {
-                                    "image": {
-                                        "contentType": ["image/png", "image/jpeg"]
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GiveawayItem"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Invalid Authentication"
-                    },
-                    "4XX": {
-                        "description": "Invalid or missing information"
-                    },
-                    "5XX": {
-                        "description": "Unexpected error"
-                    }
+            "description": "Flag used to filter out active or archived giveaways.By default returns all of them"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GiveawayListItem"
+                  }
                 }
               }
             }
@@ -754,9 +659,7 @@
               "nrPendingParticipants": { "type": "number" }
             }
           },
-          "isInvalid": {
-            "type": "boolean"
-          }
+          "isInvalid": { "type": "boolean" }
         }
       },
       "GiveawayItem": {

--- a/packages/node-app/src/utils/model.utils.ts
+++ b/packages/node-app/src/utils/model.utils.ts
@@ -60,6 +60,20 @@ export const giveawayWinners = (giveaway: any) => {
   return winners;
 };
 
+export const giveawayStatus = (giveaway: any) => {
+  if (giveaway.endTime < new Date()) {
+    if (
+      giveaway.participants.length <= 0 ||
+      giveaway.numberOfWinners > giveaway.participants.length
+    )
+      return 'invalid';
+    if (giveaway.winners.length > 0) return 'finished';
+    return 'pending';
+  }
+  if (giveaway.startTime > new Date()) return 'future';
+  return 'ongoing';
+};
+
 export const handleError = (error: Error): APIError => {
   if (error instanceof MongooseError.ValidationError) {
     const message = Object.entries(error.errors).map(([field, error]) => ({

--- a/packages/node-app/src/utils/model.utils.ts
+++ b/packages/node-app/src/utils/model.utils.ts
@@ -60,18 +60,15 @@ export const giveawayWinners = (giveaway: any) => {
   return winners;
 };
 
-export const giveawayStatus = (giveaway: any) => {
-  if (giveaway.endTime < new Date()) {
-    if (
-      giveaway.participants.length <= 0 ||
-      giveaway.numberOfWinners > giveaway.participants.length
-    )
-      return 'invalid';
-    if (giveaway.winners.length > 0) return 'finished';
-    return 'pending';
+export const isGiveawayInvalid = (giveaway: any) => {
+  let confirmedParticipants = 0;
+  for (const participant of giveaway.participants) {
+    if (participant.state === 'confirmed') confirmedParticipants++;
   }
-  if (giveaway.startTime > new Date()) return 'future';
-  return 'ongoing';
+  if (giveaway.endTime < new Date()) {
+    if (giveaway.numberOfWinners > confirmedParticipants) return true;
+  }
+  return false;
 };
 
 export const handleError = (error: Error): APIError => {

--- a/packages/node-app/src/utils/model.utils.ts
+++ b/packages/node-app/src/utils/model.utils.ts
@@ -119,6 +119,8 @@ export const getActiveGiveaways = (giveaways, role) => {
       g.endTime < new Date() && g.numberOfWinners >= g.participants.length
     );
 
+    if (isGiveawayInvalid(g)) return false;
+
     const hasPendingWinners =
       g.manual && new Date() > g.endTime && g.winners.length === 0;
 

--- a/packages/react-app/src/components/giveaways/cards/Card.tsx
+++ b/packages/react-app/src/components/giveaways/cards/Card.tsx
@@ -15,9 +15,11 @@ import {
 } from '@mui/material';
 
 import Trophy from '../../../assets/Trophy.png';
+import SadEmoji from '../../../assets/SadEmoji.png';
 import { useParticipants } from '../../../lib/queryClient';
 import {
   Giveaway,
+  GiveawayStatus,
   ParticipationState,
   UserInfo,
   UserRole,
@@ -106,6 +108,14 @@ const GiveawayCard = ({
             </div>
           </div>
         )}
+        {giveaway.status === GiveawayStatus.INVALID && (
+          <div className="invalid">
+            <div style={{ textAlign: 'center' }}>
+              <img className="icon" src={SadEmoji} alt="SadEmoji" />
+              <Typography className="message">Not enough participants</Typography>
+            </div>
+          </div>
+        )}
       </div>
       <CardContent className="giveaway-card">
         <Typography
@@ -136,7 +146,7 @@ const GiveawayCard = ({
             <span role="img" aria-label="party emoji">
               🥳
             </span>{' '}
-            {giveaway.winners.length > 0 ? getWinnerStr() : 'Pending'}
+            {giveaway.winners.length > 0 ? getWinnerStr() : 'No Winners'}
           </Typography>
         )}
         {archived && (

--- a/packages/react-app/src/components/giveaways/cards/Card.tsx
+++ b/packages/react-app/src/components/giveaways/cards/Card.tsx
@@ -19,7 +19,6 @@ import SadEmoji from '../../../assets/SadEmoji.png';
 import { useParticipants } from '../../../lib/queryClient';
 import {
   Giveaway,
-  GiveawayStatus,
   ParticipationState,
   UserInfo,
   UserRole,
@@ -90,7 +89,7 @@ const GiveawayCard = ({
       }}
       elevation={0}
     >
-      {userInfo.role === UserRole.ADMIN && nrPendingParticipants > 0 && (
+      {userInfo.role === UserRole.ADMIN && nrPendingParticipants > 0 && !giveaway.isInvalid &&(
         <div className="card-pending-approvals">
           <PendingApprovalBanner
             giveaway={giveaway}
@@ -108,7 +107,7 @@ const GiveawayCard = ({
             </div>
           </div>
         )}
-        {giveaway.status === GiveawayStatus.INVALID && (
+        {giveaway.isInvalid && (
           <div className="invalid">
             <div style={{ textAlign: 'center' }}>
               <img className="icon" src={SadEmoji} alt="SadEmoji" />
@@ -146,7 +145,7 @@ const GiveawayCard = ({
             <span role="img" aria-label="party emoji">
               🥳
             </span>{' '}
-            {giveaway.winners.length > 0 ? getWinnerStr() : 'No Winners'}
+            {giveaway.winners.length > 0 ? getWinnerStr() : giveaway.isInvalid ? 'No Winners' : 'pending'}
           </Typography>
         )}
         {archived && (

--- a/packages/react-app/src/lib/types.ts
+++ b/packages/react-app/src/lib/types.ts
@@ -11,6 +11,7 @@ type Giveaway = {
   prize: string;
   stats: Stats;
   manual: boolean;
+  status: string;
   rules?: string;
   requirements?: Requirements;
 };
@@ -83,11 +84,20 @@ type GiveawayCondition = {
   value: ConditionValue;
 };
 
+enum GiveawayStatus {
+  INVALID = 'invalid',
+  FINISHED = 'finished',
+  PENDING = 'pending',
+  FUTURE = 'future',
+  ONGOING = 'ongoing',
+}
+
 export {
   ConditionType,
   ConditionValue,
   Giveaway,
   GiveawayCondition,
+  GiveawayStatus,
   Location,
   Participant,
   ParticipationState,

--- a/packages/react-app/src/lib/types.ts
+++ b/packages/react-app/src/lib/types.ts
@@ -11,7 +11,7 @@ type Giveaway = {
   prize: string;
   stats: Stats;
   manual: boolean;
-  status: string;
+  isInvalid: boolean;
   rules?: string;
   requirements?: Requirements;
 };
@@ -84,20 +84,11 @@ type GiveawayCondition = {
   value: ConditionValue;
 };
 
-enum GiveawayStatus {
-  INVALID = 'invalid',
-  FINISHED = 'finished',
-  PENDING = 'pending',
-  FUTURE = 'future',
-  ONGOING = 'ongoing',
-}
-
 export {
   ConditionType,
   ConditionValue,
   Giveaway,
   GiveawayCondition,
-  GiveawayStatus,
   Location,
   Participant,
   ParticipationState,

--- a/packages/react-app/src/pages/manage.tsx
+++ b/packages/react-app/src/pages/manage.tsx
@@ -32,6 +32,7 @@ import { splitTimeLeft } from '../hooks/useTimer';
 import { useGiveaways } from '../lib/queryClient';
 import {
   Giveaway,
+  GiveawayStatus,
   UserInfo,
   UserRole,
 } from '../lib/types';
@@ -53,11 +54,8 @@ const Manage = () => {
 
   const giveaways = useMemo(() => {
     return data?.filter((g) => {
-      const now = new Date();
-      const giveawayStartDate = new Date(g.startTime);
-      const giveawayEndDate = new Date(g.endTime);
 
-      if (userInfo.role !== UserRole.ADMIN && giveawayStartDate > new Date()) {
+      if (userInfo.role !== UserRole.ADMIN && g.status === GiveawayStatus.FUTURE) {
         return false;
       }
 
@@ -67,13 +65,13 @@ const Manage = () => {
 
       if (
         userInfo.role === UserRole.ADMIN &&
-        ParticipationService.hasPendingWinners(g)
+        g.status === GiveawayStatus.PENDING
       )
         return activeTab === Tabs.Active;
 
       return activeTab === Tabs.Active
-        ? isAfter(giveawayEndDate, now)
-        : isBefore(giveawayEndDate, now);
+        ? (g.status === GiveawayStatus.FUTURE || g.status === GiveawayStatus.ONGOING)
+        : (g.status === GiveawayStatus.FINISHED || g.status === GiveawayStatus.INVALID);
     });
   }, [activeTab, data, countdownGiveaway]);
 

--- a/packages/react-app/src/styles/manage.scss
+++ b/packages/react-app/src/styles/manage.scss
@@ -130,6 +130,27 @@
       color: white;
     }
   }
+  .invalid {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+    height: 120px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(232, 172, 10, 0.8);
+
+    .icon {
+      width: 60px;
+    }
+
+    .message {
+      font-weight: bold;
+      font-size: 18px;
+      color: white;
+    }
+  }
 }
 
 .giveaway-card {


### PR DESCRIPTION
# Description

When a giveaway ends, and there was not enough participants to pick the determined number of winners, it now becomes archived and tagged as invalid.

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-54

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

As admin, create a giveaway with at least 1 number of winners.
Wait until giveaway timer ends, without any participant.
Confirm that the giveaway shows up in the archived tab.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
