### PR TITLE
[WEB3-4] Document auth endpoints

### DIFF
--- a/packages/node-app/src/swagger.json
+++ b/packages/node-app/src/swagger.json
@@ -536,6 +536,86 @@
                     }
                 }
             }
+        },
+        "/login": {
+            "post": {
+                "tags": ["authentication"],
+                "description": "Login user",
+                "parameters": [
+                    {
+                      "name": "tokenType",
+                      "in": "query",
+                      "required": true
+                    },
+                    {
+                        "name": "accessToken",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "API access token",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "example": {
+                                        "token": "auth-token"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid Authentication"
+                    },
+                    "5XX": {
+                        "description": "Unexpected error"
+                    }
+                }
+
+            }
+        },
+        "/me": {
+            "get": {
+                "tags": ["authentication"],
+                "description": "Get user",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "email": { "type": "string" },
+                                        "name": { "type": "string" },
+                                        "role": {
+                                            "type": "string",
+                                            "enum": ["user", "admin"]
+                                        },
+                                        "units": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": ["node", "rails", "python"]
+                                            }
+                                        },
+                                        "picture": { "type": "string" }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "4XX": {
+                        "description": "Invalid or missing information"
+                    },
+                    "5XX": {
+                        "description": "Unexpected error"
+                    }
+                }
+            }
         }
     },
     "components": {


### PR DESCRIPTION
# Description

This PR adds documentation to the authentication endpoints using Swagger.

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-4

## Type of change
New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
The documentation can be accessed via the `/api-docs` endpoint

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
