### PR TITLE
[WEB3-53] use TA person endpoint if user's TA id already exists in db

### DIFF
--- a/packages/node-app/src/models/user.model.ts
+++ b/packages/node-app/src/models/user.model.ts
@@ -17,6 +17,7 @@ export interface User extends mongoose.Document {
   picture: string;
   role: UserRole;
   units: Unit[];
+  taId: number;
 }
 
 const userSchema = new Schema<User>({
@@ -35,6 +36,7 @@ const userSchema = new Schema<User>({
     default: [],
   },
   picture: { type: String, required: false },
+  taId: { type: Number, required: true },
 });
 
 export const User = mongoose.model<User>('User', userSchema);

--- a/packages/node-app/src/utils/auth.utils.ts
+++ b/packages/node-app/src/utils/auth.utils.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { Unit } from '../models/user.model';
+import { Unit, User } from '../models/user.model';
 import TAClient from './ta.utils';
 
 const googleAuthInstance = axios.create({
@@ -19,11 +19,19 @@ const getUserInfo = async (tokenType, accessToken) => {
     if (res.status === 200) {
       const userInfo = res.data;
       const taSession = await TAClient.signIn();
-      const runtimePeople = await TAClient.getPeople(taSession, false);
+      const dbUserRecord = await User.findOne({ email: userInfo.email });
+      let taUser;
 
-      const taUser = runtimePeople.find(
-        (user) => user.email === userInfo.email
-      );
+      if (dbUserRecord?.taId) {
+        taUser = await TAClient.getPersonById(taSession, false, dbUserRecord.taId);;
+      } else {
+        const runtimePeople = await TAClient.getPeople(taSession, false);
+  
+        taUser = runtimePeople.find(
+          (user) => user.email === userInfo.email
+        );
+      }
+
       if (!taUser) {
         throw Error('user is not active');
       }
@@ -31,6 +39,10 @@ const getUserInfo = async (tokenType, accessToken) => {
       const unit = getUnits(taUser);
       if (unit) {
         userInfo.units = unit;
+      }
+
+      if (taUser) {
+        userInfo.taId = taUser.id;
       }
 
       return userInfo;

--- a/packages/node-app/src/utils/auth.utils.ts
+++ b/packages/node-app/src/utils/auth.utils.ts
@@ -41,9 +41,7 @@ const getUserInfo = async (tokenType, accessToken) => {
         userInfo.units = unit;
       }
 
-      if (taUser) {
-        userInfo.taId = taUser.id;
-      }
+      userInfo.taId = taUser.id;
 
       return userInfo;
     }

--- a/packages/node-app/src/utils/ta.utils.ts
+++ b/packages/node-app/src/utils/ta.utils.ts
@@ -51,5 +51,25 @@ const getPeople = async (
   }
 };
 
-const TAClient = { signIn, getPeople };
+const getPersonById = async (
+  session: TASession,
+  archived: boolean,
+  id: number,
+): Promise<TAPerson> => {
+  const multiSite = session.siteUrl;
+  const queryParams = archived ? `?archived=${archived}` : '';
+
+  const res = await TAInstance.get(`/v1/${multiSite}/people/${id}`, {
+    headers: {
+      'access-token': session.accessToken,
+      uid: session.email,
+    },
+  });
+
+  if (res.status === 200) {
+    return res.data.person;
+  }
+};
+
+const TAClient = { signIn, getPeople, getPersonById };
 export default TAClient;


### PR DESCRIPTION
…nt if a record of that user's team allocator id, taId, already exists in the db, add taId field to user model

---
name: "Pull Request"
about: "UUse TA person endpoint if the user already exist on db"
title: "[WEB3-53] <Use TA person endpoint if the user already exist on db>"
---

# Description

add logic to the getUserInfo to use get person by id endpoint if a record of that user's team allocator id,
taId, already exists in the db, add taId field to user model

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-53

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test login flow

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
