### PR TITLE
[WEB3-65] make the participants endpoint admin only, adapt frontend t…

### DIFF
--- a/packages/node-app/src/controllers/giveaway.controller.ts
+++ b/packages/node-app/src/controllers/giveaway.controller.ts
@@ -276,9 +276,27 @@ export const addParticipant = async (req: Request, res: Response) => {
 export const getParticipants = async (req: Request, res: Response) => {
   try {
     const giveaway = await Giveaway.findById(req.params.id);
-    if (!giveaway) return res.status(404).json({ error: 'Giveaway not found' });
+    if (req.user.role === 'admin') {
+      if (!giveaway)
+        return res.status(404).json({ error: 'Giveaway not found' });
 
-    res.status(200).json(giveaway.participants);
+      res.status(200).json(giveaway.participants);
+    } else {
+      const userParticipation = giveaway?.participants?.find(
+        (el) => el.id === req.user.id
+      );
+      if (userParticipation) {
+        res
+          .status(200)
+          .json({
+            message: 'Participation found',
+            state: userParticipation.state,
+            notified: userParticipation.notified,
+          });
+      } else {
+        res.status(200).json({ message: 'No participation found', state: '' });
+      }
+    }
   } catch (error) {
     const { code, message } = handleError(error);
     res.status(code).json({ error: message });

--- a/packages/node-app/src/controllers/giveaway.controller.ts
+++ b/packages/node-app/src/controllers/giveaway.controller.ts
@@ -276,10 +276,10 @@ export const addParticipant = async (req: Request, res: Response) => {
 export const getParticipants = async (req: Request, res: Response) => {
   try {
     const giveaway = await Giveaway.findById(req.params.id);
-    if (req.user.role === 'admin') {
-      if (!giveaway)
-        return res.status(404).json({ error: 'Giveaway not found' });
+    if (!giveaway)
+      return res.status(404).json({ error: 'Giveaway not found' });
 
+    if (req.user.role === UserRole.ADMIN) {
       res.status(200).json(giveaway.participants);
     } else {
       const userParticipation = giveaway?.participants?.find(
@@ -288,13 +288,9 @@ export const getParticipants = async (req: Request, res: Response) => {
       if (userParticipation) {
         res
           .status(200)
-          .json({
-            message: 'Participation found',
-            state: userParticipation.state,
-            notified: userParticipation.notified,
-          });
+          .json([userParticipation]);
       } else {
-        res.status(200).json({ message: 'No participation found', state: '' });
+        res.status(200).json([]);
       }
     }
   } catch (error) {

--- a/packages/react-app/src/components/giveaways/cards/Card.tsx
+++ b/packages/react-app/src/components/giveaways/cards/Card.tsx
@@ -53,7 +53,13 @@ const GiveawayCard = ({
     if (winners.length === 0) return;
 
     const winnerId = winners[0].id;
-    const winnerParticipant = participants?.find((p) => p.id === winnerId);
+    let winnerParticipant;
+
+    if (userInfo.role === UserRole.ADMIN) {
+      winnerParticipant = participants.find((p) => p.id === winnerId);
+    } else {
+      winnerParticipant = participants.pop();
+    }
 
     if (winnerParticipant) {
       if (winners.length === 1) {

--- a/packages/react-app/src/components/giveaways/cards/Card.tsx
+++ b/packages/react-app/src/components/giveaways/cards/Card.tsx
@@ -42,7 +42,6 @@ const GiveawayCard = ({
 }: GiveawayCardProps) => {
   const navigate = useNavigate();
   const userInfo = useContext(UserContext) as UserInfo;
-  const { data: participants } = useParticipants(giveaway._id);
   const [participation, setParticipation] = useState<ParticipationState>();
   const isWinner = ParticipationService.wonGiveaway(giveaway, userInfo);
   const nrConfirmedParticipants = giveaway.stats.nrConfirmedParticipants;
@@ -109,16 +108,6 @@ const GiveawayCard = ({
               <img className="winner-icon" src={Trophy} alt="Trophy" />
               <Typography className="winner-message">
                 You won this contest!
-              </Typography>
-            </div>
-          </div>
-        )}
-        {giveaway.status === GiveawayStatus.INVALID && (
-          <div className="invalid-giveaway">
-            <div className="center-text">
-              <img className="invalid-icon" src={SadEmoji} alt="SadEmoji" />
-              <Typography className="invalid-message">
-                Not enough participants
               </Typography>
             </div>
           </div>

--- a/packages/react-app/src/components/giveaways/cards/Card.tsx
+++ b/packages/react-app/src/components/giveaways/cards/Card.tsx
@@ -52,20 +52,13 @@ const GiveawayCard = ({
     const winners = giveaway.winners;
     if (winners.length === 0) return;
 
-    const winnerId = winners[0].id;
-    let winnerParticipant;
-
-    if (userInfo.role === UserRole.ADMIN) {
-      winnerParticipant = participants.find((p) => p.id === winnerId);
-    } else {
-      winnerParticipant = participants.pop();
-    }
+    const winnerParticipant = winners[0];
 
     if (winnerParticipant) {
       if (winners.length === 1) {
-        return `${winnerParticipant.name}`;
+        return winners[0].name;
       } else {
-        return `${winnerParticipant.name} +${winners.length - 1} more`;
+        return `${winners[0].name} + ${winners.length - 1} more`;
       }
     }
   };

--- a/packages/react-app/src/components/giveaways/details/MainContent.tsx
+++ b/packages/react-app/src/components/giveaways/details/MainContent.tsx
@@ -9,11 +9,9 @@ import { GiveawayContext } from '../../../pages/details';
 import { UserContext } from '../../../routes/AuthRoute';
 import PendingApprovalBanner from '../participation/PendingApprovalBanner';
 
-type GiveawayMainContentProps = {
-  participants: Participant[];
-};
+type GiveawayMainContentProps = {};
 
-const GiveawayMainContent = ({ participants }: GiveawayMainContentProps) => {
+const GiveawayMainContent = () => {
   const userInfo = useContext(UserContext) as UserInfo;
   const giveaway = useContext(GiveawayContext) as Giveaway;
   const isAdmin = userInfo.role === UserRole.ADMIN;
@@ -94,7 +92,7 @@ const GiveawayMainContent = ({ participants }: GiveawayMainContentProps) => {
               </span>{' '}
               {`${nrConfirmedParticipants} participants`}
             </Typography>
-            {!isAdmin && participants && (
+            {!isAdmin && nrConfirmedParticipants && (
               <span className="winning-chance">{`You have a ${winningChance}% chance of winning`}</span>
             )}
           </div>

--- a/packages/react-app/src/components/giveaways/details/MainContent.tsx
+++ b/packages/react-app/src/components/giveaways/details/MainContent.tsx
@@ -1,10 +1,10 @@
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 
 import { format } from 'date-fns';
 
 import { Stack, Typography } from '@mui/material';
 
-import { Giveaway, Participant, UserInfo, UserRole } from '../../../lib/types';
+import { Giveaway, UserInfo, UserRole } from '../../../lib/types';
 import { GiveawayContext } from '../../../pages/details';
 import { UserContext } from '../../../routes/AuthRoute';
 import PendingApprovalBanner from '../participation/PendingApprovalBanner';

--- a/packages/react-app/src/components/giveaways/details/MainContent.tsx
+++ b/packages/react-app/src/components/giveaways/details/MainContent.tsx
@@ -9,8 +9,6 @@ import { GiveawayContext } from '../../../pages/details';
 import { UserContext } from '../../../routes/AuthRoute';
 import PendingApprovalBanner from '../participation/PendingApprovalBanner';
 
-type GiveawayMainContentProps = {};
-
 const GiveawayMainContent = () => {
   const userInfo = useContext(UserContext) as UserInfo;
   const giveaway = useContext(GiveawayContext) as Giveaway;

--- a/packages/react-app/src/lib/types.ts
+++ b/packages/react-app/src/lib/types.ts
@@ -14,6 +14,8 @@ type Giveaway = {
   isInvalid: boolean;
   rules?: string;
   requirements?: Requirements;
+  winningChance: number;
+  status: string;
 };
 
 type UserInfo = {

--- a/packages/react-app/src/lib/types.ts
+++ b/packages/react-app/src/lib/types.ts
@@ -14,6 +14,7 @@ type Giveaway = {
   isInvalid: boolean;
   rules?: string;
   requirements?: Requirements;
+  winningChance: number;
 };
 
 type UserInfo = {

--- a/packages/react-app/src/lib/types.ts
+++ b/packages/react-app/src/lib/types.ts
@@ -14,8 +14,6 @@ type Giveaway = {
   isInvalid: boolean;
   rules?: string;
   requirements?: Requirements;
-  winningChance: number;
-  status: string;
 };
 
 type UserInfo = {

--- a/packages/react-app/src/pages/details.tsx
+++ b/packages/react-app/src/pages/details.tsx
@@ -23,7 +23,6 @@ const loader = async ({ params }: any) => {
 const GiveawayDetailsPage = () => {
   const giveaway = useLoaderData() as Giveaway;
   const revalidator = useRevalidator();
-  const { data: participants, refetch } = useParticipants(giveaway._id);
   const participationState = useRef<ParticipationState>();
 
   const onParticipationChange = (newState: ParticipationState) => {
@@ -43,7 +42,7 @@ const GiveawayDetailsPage = () => {
         justifyContent="center"
         sx={{ flexDirection: { xs: 'column', md: 'row' } }}
       >
-        {participants && <GiveawayMainContent participants={participants} />}
+        <GiveawayMainContent />
         <GiveawayAsideContent onParticipationChange={onParticipationChange} />
       </Stack>
     </GiveawayContext.Provider>

--- a/packages/react-app/src/services/giveawayparticipation.ts
+++ b/packages/react-app/src/services/giveawayparticipation.ts
@@ -57,9 +57,9 @@ const getParticipationState = async (
   let registeredUser;
 
   if (userInfo.role === UserRole.ADMIN) {
-    registeredUser = participants?.find((p) => p.id === userInfo.email);
+    registeredUser = participants.find((p) => p.id === userInfo.email);
   } else {
-    registeredUser = participants;
+    registeredUser = participants.pop();
   }
 
   if (registeredUser) {
@@ -128,7 +128,13 @@ const shouldNotifyWinner = async (
 ): Promise<boolean> => {
   if (giveaway.winners.some((w) => w.id === userInfo.email)) {
     const participants = await FrontendApiClient.getParticipants(giveaway._id);
-    const userObj = participants.find((p) => p.id === userInfo.email);
+    let userObj;
+
+    if (userInfo.role === UserRole.ADMIN) {
+      userObj = participants.find((p) => p.id === userInfo.email);
+    } else {
+      userObj = participants.pop();
+    }
 
     if (userObj && !userObj.notified) {
       return true;

--- a/packages/react-app/src/services/giveawayparticipation.ts
+++ b/packages/react-app/src/services/giveawayparticipation.ts
@@ -56,7 +56,7 @@ const getParticipationState = async (
 
   let registeredUser;
 
-  if (userInfo.role === 'admin') {
+  if (userInfo.role === UserRole.ADMIN) {
     registeredUser = participants?.find((p) => p.id === userInfo.email);
   } else {
     registeredUser = participants;

--- a/packages/react-app/src/services/giveawayparticipation.ts
+++ b/packages/react-app/src/services/giveawayparticipation.ts
@@ -53,7 +53,14 @@ const getParticipationState = async (
 
   if (!participants)
     participants = await FrontendApiClient.getParticipants(giveaway._id);
-  const registeredUser = participants.find((p) => p.id === userInfo.email);
+
+  let registeredUser;
+
+  if (userInfo.role === 'admin') {
+    registeredUser = participants?.find((p) => p.id === userInfo.email);
+  } else {
+    registeredUser = participants;
+  }
 
   if (registeredUser) {
     switch (registeredUser.state) {


### PR DESCRIPTION
---
name: "Pull Request"
about: "make the participants endpoint admin only"
title: "[WEB3-65] make the participants endpoint admin only"
---

# Description

make the participants admin only and adapt frontend to get the current user's participation state if not admin

Ticket: https://runtime-revolution.atlassian.net/browse/WEB3-65

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## How Has This Been Tested?

Loading a giveaway's details

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
